### PR TITLE
Add summary statistics to webpage

### DIFF
--- a/docs/assets/repositories.js
+++ b/docs/assets/repositories.js
@@ -177,7 +177,12 @@ function rolling_average(dates, requests, window = 28) {
             "range": ["2013-01-01", to_date(new Date())],
             "title": "Count"
         }
-    }    
+    }
+    load_json("summary.json", function (data) {
+        Object.keys(data).map(function (key) {
+            document.getElementById(key).textContent = data[key]
+        });
+    });
     load_json("download_stats.json", function (data) {
         var chart = d3.select('#chart_download_statistics').node();
         visible = new Set(["JuMP.jl", "HiGHS.jl"]);

--- a/docs/repositories/index.html
+++ b/docs/repositories/index.html
@@ -34,6 +34,18 @@ in the LICENSE.md file or at https://opensource.org/licenses/MIT.
                 We also track <a href="../index.html">performance benchmarks</a>.
             </p>
             <div class="divider"></div>
+            <div class="small-text">
+            <p>
+                In the last 12 months of jump-dev, there have been:
+                <ul>
+                    <li>at least <span id="n_downloads"></span> downloads of packages, as measured by Julia's package servers and excluding CI jobs</li>
+                    <li><span id="prs_opened"></span> pull requests opened</li>
+                    <li><span id="issues_opened"></span> issues opened</li>
+                    <li><span id="num_contributors"></span> unique contributors who have opened a PR</li>
+                </ul>
+            </p>
+            </div>
+            <div class="divider"></div>
             <ol class="small-text">
                 <li><a href="#chart_download_statistics">User downloads by package</a></li>
                 <li><a href="#chart_pr_activity">Pull request activity by month</a></li>

--- a/docs/repositories/summary.json
+++ b/docs/repositories/summary.json
@@ -1,0 +1,1 @@
+{"issues_opened":373,"n_downloads":694977,"prs_opened":1174,"num_contributors":52}

--- a/scripts/repositories.jl
+++ b/scripts/repositories.jl
@@ -260,6 +260,16 @@ function state_of_jump_statistics()
             end
         end
     end
+    open(joinpath(DATA_DIR, "summary.json"), "w") do io
+        summary = Dict(
+            "n_downloads" => n_downloads,
+            "prs_opened" => prs_opened,
+            "issues_opened" => issues_opened,
+            "num_contributors" => length(contributors),
+        )
+        write(io, JSON.json(summary))
+        return
+    end
     println("""
     Downloads            : >$n_downloads
     Pull requests opened : $prs_opened


### PR DESCRIPTION
Mostly useful to the future. Not pretty:
![image](https://github.com/user-attachments/assets/aa5cdf8a-67db-4f75-86f4-d1ca5a900110)
